### PR TITLE
Create .well-known/org.flathub.VerifiedApps.txt

### DIFF
--- a/.well-known/org.flathub.VerifiedApps.txt
+++ b/.well-known/org.flathub.VerifiedApps.txt
@@ -1,0 +1,5 @@
+# Flathub Verification
+# See: https://docs.flathub.org/docs/for-app-authors/verification/
+
+# net.hhoney.rota
+bd87b874-742f-4568-8e94-dc6f1fe74ba7


### PR DESCRIPTION
This will allow Flathub to mark [the ROTA listing](https://flathub.org/apps/net.hhoney.rota) as verified

See: https://docs.flathub.org/docs/for-app-authors/verification/

The specific token is from https://flathub.org/apps/manage/net.hhoney.rota