### PR TITLE
Flathub: Verify Candy Wrapper and Tiny Crate

### DIFF
--- a/.well-known/org.flathub.VerifiedApps.txt
+++ b/.well-known/org.flathub.VerifiedApps.txt
@@ -1,1 +1,8 @@
+# Candy Wrapper (net.hhoney.candy)
+c04b55dc-b032-4666-9f37-040953be2abd
+
+# ROTA (net.hhoney.rota)
 ccb9847a-af28-409b-b03c-adb229e680ce
+
+# Tiny Crate (net.hhoney.tinycrate)
+2d9e62d2-b375-4fa5-be72-b655386156d6


### PR DESCRIPTION
Tokens from https://flathub.org/apps/manage/net.hhoney.candy and https://flathub.org/apps/manage/net.hhoney.tinycrate

Added comments to make the file a bit more readable/maintainable.

Flathub documentation: https://docs.flathub.org/docs/for-app-authors/verification

Once this is live, we can continue with verification on the Flathub side.